### PR TITLE
Introduce MustBe/MustHave variations

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/throup/couldbe/scala.yml)](https://github.com/throup/couldbe/actions/workflows/scala.yml)
 [![couldbe Scala version support](https://index.scala-lang.org/throup/couldbe/couldbe/latest-by-scala-version.svg?platform=jvm)](https://index.scala-lang.org/throup/couldbe/couldbe)
 [![codecov](https://codecov.io/gh/throup/couldbe/branch/main/graph/badge.svg?token=XSUAQWYIOO)](https://codecov.io/gh/throup/couldbe)
-[![javadoc](https://javadoc.io/badge2/eu.throup/couldbe_3/javadoc.svg)](https://javadoc.io/doc/eu.throup/couldbe)
+[![javadoc](https://javadoc.io/badge2/eu.throup/couldbe-core_3/javadoc.svg)](https://javadoc.io/doc/eu.throup/couldbe-core_3)
 
 ![Cats Friendly Badge](https://typelevel.org/cats/img/cats-badge-tiny.png)
 

--- a/core/src/main/scala-2.13/eu/throup/couldbe/MustBeGivenEitherCompanion.scala
+++ b/core/src/main/scala-2.13/eu/throup/couldbe/MustBeGivenEitherCompanion.scala
@@ -1,0 +1,17 @@
+package eu.throup
+package couldbe
+
+private[couldbe] trait MustBeGivenEitherCompanion {
+  // Be Right-biased -- if there is a B, we don't care whether there is an A
+  implicit def implicitIsGivenRight[A, B](implicit b: B): MustBeGivenEither[A, B] = isGivenRight(b)
+
+  implicit def implicitIsGivenLeft[A, B: NotGiven](implicit a: A): MustBeGivenEither[A, B] = isGivenLeft(a)
+
+  def apply[A, B](implicit ge: MustBeGivenEither[A, B]): MustBeGivenEither[A, B] = ge
+
+  def act[A, B, C](f: A => C)(g: B => C)(implicit ge: MustBeGivenEither[A, B]): C = ge.act(f)(g)
+
+  def isGivenLeft[A, B](a: A): MustBeGivenEither[A, B] = IsGivenLeft(a)
+
+  def isGivenRight[A, B](b: B): MustBeGivenEither[A, B] = IsGivenRight(b)
+}

--- a/core/src/main/scala-2.13/eu/throup/couldbe/MustBeGivenOneOf1Companion.scala
+++ b/core/src/main/scala-2.13/eu/throup/couldbe/MustBeGivenOneOf1Companion.scala
@@ -1,0 +1,6 @@
+package eu.throup
+package couldbe
+
+private[couldbe] trait MustBeGivenOneOf1Companion {
+  def apply[A](implicit a: A): MustBeGivenOneOf1[A] = IsGiven1Of1(a)
+}

--- a/core/src/main/scala-2.13/eu/throup/couldbe/MustBeGivenOneOf2Companion.scala
+++ b/core/src/main/scala-2.13/eu/throup/couldbe/MustBeGivenOneOf2Companion.scala
@@ -1,0 +1,7 @@
+package eu.throup
+package couldbe
+
+private[couldbe] trait MustBeGivenOneOf2Companion {
+  def apply[A, B](implicit a: A): MustBeGivenOneOf2[A, B]           = IsGiven1Of2(a)
+  def apply[A: NotGiven, B](implicit b: B): MustBeGivenOneOf2[A, B] = IsGiven2Of2(b)
+}

--- a/core/src/main/scala-2.13/eu/throup/couldbe/MustBeGivenOneOf3Companion.scala
+++ b/core/src/main/scala-2.13/eu/throup/couldbe/MustBeGivenOneOf3Companion.scala
@@ -1,0 +1,10 @@
+package eu.throup
+package couldbe
+
+private[couldbe] trait MustBeGivenOneOf3Companion {
+  implicit def implicitIsGiven1of3[A, B, C](implicit a: A): MustBeGivenOneOf3[A, B, C]           = IsGiven1Of3(a)
+  implicit def implicitIsGiven2of3[A: NotGiven, B, C](implicit b: B): MustBeGivenOneOf3[A, B, C] = IsGiven2Of3(b)
+  implicit def implicitIsGiven3of3[A: NotGiven, B: NotGiven, C](implicit c: C): MustBeGivenOneOf3[A, B, C] =
+    IsGiven3Of3(c)
+  def apply[A, B, C](implicit mbg: MustBeGivenOneOf3[A, B, C]): MustBeGivenOneOf3[A, B, C] = mbg
+}

--- a/core/src/main/scala-2.13/eu/throup/couldbe/MustBeOneOf3.scala
+++ b/core/src/main/scala-2.13/eu/throup/couldbe/MustBeOneOf3.scala
@@ -1,0 +1,8 @@
+package eu.throup
+package couldbe
+
+object MustBeOneOf3 {
+  def apply[F[_[_]], G[_[_]], H[_[_]], A[_]](implicit
+      gefgh: MustBeGivenOneOf3[F[A], G[A], H[A]]
+  ): MustBeOneOf3[F, G, H, A] = gefgh
+}

--- a/core/src/main/scala-2.13/eu/throup/couldbe/package.scala
+++ b/core/src/main/scala-2.13/eu/throup/couldbe/package.scala
@@ -3,4 +3,6 @@ package eu.throup
 package object couldbe {
   type CouldBe[F[_[_]], A[_]] = CouldBeGiven[F[A]]
   type CouldHave[F[_], A]     = CouldBeGiven[F[A]]
+
+  type MustBeOneOf3[F[_[_]], G[_[_]], H[_[_]], A[_]] = MustBeGivenOneOf3[F[A], G[A], H[A]]
 }

--- a/core/src/main/scala-3/eu/throup/couldbe/CouldBeGivenCompanion.scala
+++ b/core/src/main/scala-3/eu/throup/couldbe/CouldBeGivenCompanion.scala
@@ -4,7 +4,7 @@ package couldbe
 private[couldbe] trait CouldBeGivenCompanion:
   given [A](using a: A): CouldBeGiven[A] = isGiven(a)
 
-  given [A](using NotGiven[A]): CouldBeGiven[A] = isNotGiven
+  given [A: NotGiven]: CouldBeGiven[A] = isNotGiven
 
   def apply[A](using go: CouldBeGiven[A]): CouldBeGiven[A] = go
 

--- a/core/src/main/scala-3/eu/throup/couldbe/MustBeEither.scala
+++ b/core/src/main/scala-3/eu/throup/couldbe/MustBeEither.scala
@@ -1,0 +1,6 @@
+package eu.throup
+package couldbe
+
+type MustBeEither = [F[_[_]], G[_[_]]] =>> [A[_]] =>> MustBeGivenEither[F[A], G[A]]
+object MustBeEither:
+  def apply[F[_[_]], G[_[_]], A[_]](using gefg: MustBeGivenEither[F[A], G[A]]): MustBeEither[F, G][A] = gefg

--- a/core/src/main/scala-3/eu/throup/couldbe/MustBeGivenEitherCompanion.scala
+++ b/core/src/main/scala-3/eu/throup/couldbe/MustBeGivenEitherCompanion.scala
@@ -1,0 +1,16 @@
+package eu.throup
+package couldbe
+
+private[couldbe] trait MustBeGivenEitherCompanion:
+  // Be Right-biased -- if there is a B, we don't care whether there is an A
+  given [A, B](using b: B): MustBeGivenEither[A, B] = isGivenRight(b)
+
+  given [A, B: NotGiven](using a: A): MustBeGivenEither[A, B] = isGivenLeft(a)
+
+  def apply[A, B](using ge: MustBeGivenEither[A, B]): MustBeGivenEither[A, B] = ge
+
+  def act[A, B, C](f: A => C)(g: B => C)(using ge: MustBeGivenEither[A, B]): C = ge.act(f)(g)
+
+  def isGivenLeft[A, B](a: A): MustBeGivenEither[A, B] = IsGivenLeft(a)
+
+  def isGivenRight[A, B](b: B): MustBeGivenEither[A, B] = IsGivenRight(b)

--- a/core/src/main/scala-3/eu/throup/couldbe/MustBeGivenOneOf1Companion.scala
+++ b/core/src/main/scala-3/eu/throup/couldbe/MustBeGivenOneOf1Companion.scala
@@ -1,0 +1,5 @@
+package eu.throup
+package couldbe
+
+private[couldbe] trait MustBeGivenOneOf1Companion:
+  def apply[A](using a: A): MustBeGivenOneOf1[A] = IsGiven1Of1(a)

--- a/core/src/main/scala-3/eu/throup/couldbe/MustBeGivenOneOf2Companion.scala
+++ b/core/src/main/scala-3/eu/throup/couldbe/MustBeGivenOneOf2Companion.scala
@@ -1,0 +1,6 @@
+package eu.throup
+package couldbe
+
+private[couldbe] trait MustBeGivenOneOf2Companion:
+  def apply[A, B](using a: A): MustBeGivenOneOf2[A, B]           = IsGiven1Of2(a)
+  def apply[A: NotGiven, B](using b: B): MustBeGivenOneOf2[A, B] = IsGiven2Of2(b)

--- a/core/src/main/scala-3/eu/throup/couldbe/MustBeGivenOneOf3Companion.scala
+++ b/core/src/main/scala-3/eu/throup/couldbe/MustBeGivenOneOf3Companion.scala
@@ -1,0 +1,8 @@
+package eu.throup
+package couldbe
+
+private[couldbe] trait MustBeGivenOneOf3Companion:
+  given [A, B, C](using a: A): MustBeGivenOneOf3[A, B, C]                               = IsGiven1Of3(a)
+  given [A: NotGiven, B, C](using b: B): MustBeGivenOneOf3[A, B, C]                     = IsGiven2Of3(b)
+  given [A: NotGiven, B: NotGiven, C](using c: C): MustBeGivenOneOf3[A, B, C]           = IsGiven3Of3(c)
+  def apply[A, B, C](using mbg: MustBeGivenOneOf3[A, B, C]): MustBeGivenOneOf3[A, B, C] = mbg

--- a/core/src/main/scala-3/eu/throup/couldbe/MustBeOneOf3.scala
+++ b/core/src/main/scala-3/eu/throup/couldbe/MustBeOneOf3.scala
@@ -1,0 +1,8 @@
+package eu.throup
+package couldbe
+
+type MustBeOneOf3 = [F[_[_]], G[_[_]], H[_[_]]] =>> [A[_]] =>> MustBeGivenOneOf3[F[A], G[A], H[A]]
+object MustBeOneOf3:
+  def apply[F[_[_]], G[_[_]], H[_[_]], A[_]](using
+      gefgh: MustBeGivenOneOf3[F[A], G[A], H[A]]
+  ): MustBeOneOf3[F, G, H][A] = gefgh

--- a/core/src/main/scala-3/eu/throup/couldbe/MustHaveEither.scala
+++ b/core/src/main/scala-3/eu/throup/couldbe/MustHaveEither.scala
@@ -1,0 +1,6 @@
+package eu.throup
+package couldbe
+
+type MustHaveEither = [F[_], G[_]] =>> [A] =>> MustBeGivenEither[F[A], G[A]]
+object MustHaveEither:
+  def apply[F[_], G[_], A](using gefg: MustBeGivenEither[F[A], G[A]]): MustHaveEither[F, G][A] = gefg

--- a/core/src/main/scala/eu/throup/couldbe/MustBeGivenEither.scala
+++ b/core/src/main/scala/eu/throup/couldbe/MustBeGivenEither.scala
@@ -1,0 +1,35 @@
+package eu.throup
+package couldbe
+
+sealed trait MustBeGivenEither[+A, +B] {
+  def isLeft: Boolean
+  def isRight: Boolean = !isLeft
+
+  def toLeft[C >: A](fromRight: B => C): C
+  def toRight[C >: B](fromLeft: A => C): C
+
+  def act[C](f: A => C)(g: B => C): C
+
+  def toEither: Either[A, B] = act[Either[A, B]](Left[A, B])(Right[A, B])
+}
+object MustBeGivenEither extends MustBeGivenEitherCompanion
+
+case class IsGivenLeft[+A, +B](get: A) extends MustBeGivenEither[A, B] {
+  override def isLeft: Boolean = true
+
+  override def toLeft[C >: A](fromRight: B => C): C = get
+
+  override def toRight[C >: B](fromLeft: A => C): C = fromLeft(get)
+
+  override def act[C](f: A => C)(g: B => C): C = f(get)
+}
+
+case class IsGivenRight[+A, +B](get: B) extends MustBeGivenEither[A, B] {
+  override def isLeft: Boolean = false
+
+  override def toLeft[C >: A](fromRight: B => C): C = fromRight(get)
+
+  override def toRight[C >: B](fromLeft: A => C): C = get
+
+  override def act[C](f: A => C)(g: B => C): C = g(get)
+}

--- a/core/src/main/scala/eu/throup/couldbe/MustBeGivenOneOf1.scala
+++ b/core/src/main/scala/eu/throup/couldbe/MustBeGivenOneOf1.scala
@@ -1,0 +1,12 @@
+package eu.throup
+package couldbe
+
+sealed trait MustBeGivenOneOf1[+A] {
+  def _1: A
+}
+
+case class IsGiven1Of1[+A](a: A) extends MustBeGivenOneOf1[A] {
+  override def _1: A = a
+}
+
+object MustBeGivenOneOf1 extends MustBeGivenOneOf1Companion

--- a/core/src/main/scala/eu/throup/couldbe/MustBeGivenOneOf2.scala
+++ b/core/src/main/scala/eu/throup/couldbe/MustBeGivenOneOf2.scala
@@ -1,0 +1,22 @@
+package eu.throup
+package couldbe
+
+sealed trait MustBeGivenOneOf2[+A, +B] {
+  def _1[Z >: A](f: B => Z): Z
+
+  def _2[Z >: B](f: A => Z): Z
+
+}
+case class IsGiven1Of2[+A, +B](a: A) extends MustBeGivenOneOf2[A, B] {
+  override def _1[Z >: A](f: B => Z): Z = a
+
+  override def _2[Z >: B](f: A => Z): Z = f(a)
+}
+
+case class IsGiven2Of2[+A, +B](b: B) extends MustBeGivenOneOf2[A, B] {
+  override def _1[Z >: A](f: B => Z): Z = f(b)
+
+  override def _2[Z >: B](f: A => Z): Z = b
+}
+
+object MustBeGivenOneOf2 extends MustBeGivenOneOf2Companion

--- a/core/src/main/scala/eu/throup/couldbe/MustBeGivenOneOf3.scala
+++ b/core/src/main/scala/eu/throup/couldbe/MustBeGivenOneOf3.scala
@@ -1,0 +1,42 @@
+package eu.throup
+package couldbe
+
+sealed trait MustBeGivenOneOf3[+A, +B, +C] {
+  def _1[Z >: A](f: B => Z)(g: C => Z): Z
+
+  def _2[Z >: B](f: A => Z)(g: C => Z): Z
+
+  def _3[Z >: C](f: A => Z)(g: B => Z): Z
+
+  def act[Z](f: A => Z)(g: B => Z)(h: C => Z): Z =
+    this match {
+      case IsGiven1Of3(a) => f(a)
+      case IsGiven2Of3(b) => g(b)
+      case IsGiven3Of3(c) => h(c)
+    }
+}
+case class IsGiven1Of3[+A, +B, +C](a: A) extends MustBeGivenOneOf3[A, B, C] {
+  override def _1[Z >: A](f: B => Z)(g: C => Z): Z = a
+
+  override def _2[Z >: B](f: A => Z)(g: C => Z): Z = f(a)
+
+  override def _3[Z >: C](f: A => Z)(g: B => Z): Z = f(a)
+}
+
+case class IsGiven2Of3[+A, +B, +C](b: B) extends MustBeGivenOneOf3[A, B, C] {
+  override def _1[Z >: A](f: B => Z)(g: C => Z): Z = f(b)
+
+  override def _2[Z >: B](f: A => Z)(g: C => Z): Z = b
+
+  override def _3[Z >: C](f: A => Z)(g: B => Z): Z = g(b)
+}
+
+case class IsGiven3Of3[+A, +B, +C](c: C) extends MustBeGivenOneOf3[A, B, C] {
+  override def _1[Z >: A](f: B => Z)(g: C => Z): Z = g(c)
+
+  override def _2[Z >: B](f: A => Z)(g: C => Z): Z = g(c)
+
+  override def _3[Z >: C](f: A => Z)(g: B => Z): Z = c
+}
+
+object MustBeGivenOneOf3 extends MustBeGivenOneOf3Companion

--- a/testsuite/src/test/scala-2.13/eu/throup/couldbe/testfixtures/ExampleFunction.scala
+++ b/testsuite/src/test/scala-2.13/eu/throup/couldbe/testfixtures/ExampleFunction.scala
@@ -21,9 +21,18 @@ object ExampleFunction {
   ): F[String] =
     if (n == 1) Monad[F].pure("That's great!")
     else
-      CouldBe[MonadThrow, F].act(_.raiseError[String](new Exception("It's gone wrong!"))) { () =>
-        CouldBe[MonadStringFailure, F].act(_.raiseError[String]("It's gone wrong!")) { () =>
-          CouldBe[MonadSilentFailure, F].act(_.raiseError[String](()))(() => throw new Exception("It's gone wrong!"))
+      MT.act(_.raiseError[String](new Exception("It's gone wrong!"))) { () =>
+        MSF.act(_.raiseError[String]("It's gone wrong!")) { () =>
+          MSS.act(_.raiseError[String](()))(() => throw new Exception("It's gone wrong!"))
         }
       }
+
+  def willFailIfNotTwo[F[_]: Monad](
+      n: Int
+  )(implicit MM: MustBeOneOf3[MonadThrow, MonadStringFailure, MonadSilentFailure, F]): F[String] =
+    if (n == 2) Monad[F].pure("That's great!")
+    else
+      MM.act(_.raiseError[String](new Exception("It's gone wrong!")))(_.raiseError[String]("It's gone wrong!"))(
+        _.raiseError[String](())
+      )
 }

--- a/testsuite/src/test/scala-3/eu/throup/couldbe/testfixtures/ExampleFunction.scala
+++ b/testsuite/src/test/scala-3/eu/throup/couldbe/testfixtures/ExampleFunction.scala
@@ -24,3 +24,12 @@ object ExampleFunction:
           CouldBe[MonadSilentFailure, F].act(_.raiseError(()))(() => throw new Exception("It's gone wrong!"))
         }
       }
+
+  def willFailIfNotTwo[F[_]: Monad: MustBeOneOf3[MonadThrow, MonadStringFailure, MonadSilentFailure]](
+      n: Int
+  ): F[String] =
+    if n == 2 then Monad[F].pure("That's great!")
+    else
+      MustBeOneOf3[MonadThrow, MonadStringFailure, MonadSilentFailure, F].act(
+        _.raiseError(new Exception("It's gone wrong!"))
+      )(_.raiseError("It's gone wrong!"))(_.raiseError(()))

--- a/testsuite/src/test/scala/eu/throup/couldbe/Compiler_CouldBe_Test.scala
+++ b/testsuite/src/test/scala/eu/throup/couldbe/Compiler_CouldBe_Test.scala
@@ -9,7 +9,7 @@ import org.scalatest.matchers.should.Matchers
 
 import scala.util.{Failure, Success, Try}
 
-class CompilerTest extends AnyFreeSpec with Matchers {
+class Compiler_CouldBe_Test extends AnyFreeSpec with Matchers {
   "Try error handling" - {
     "Success" - {
       "For Try" in {

--- a/testsuite/src/test/scala/eu/throup/couldbe/Compiler_MustBeOneOf3_Test.scala
+++ b/testsuite/src/test/scala/eu/throup/couldbe/Compiler_MustBeOneOf3_Test.scala
@@ -1,0 +1,55 @@
+package eu.throup
+package couldbe
+
+import testfixtures.CustomType.*
+import testfixtures.ExampleFunction
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
+
+import scala.util.{Failure, Success, Try}
+
+class Compiler_MustBeOneOf3_Test extends AnyFreeSpec with Matchers {
+  "Try error handling" - {
+    "Success" - {
+      "For Try" in {
+        ExampleFunction.willFailIfNotTwo[Try](2) shouldBe Success("That's great!")
+      }
+      "For Option" in {
+        ExampleFunction.willFailIfNotTwo[Option](2) shouldBe Some("That's great!")
+      }
+      "For Either[_, Throwable]" in {
+        ExampleFunction.willFailIfNotTwo[EitherThrowable](2) shouldBe Right("That's great!")
+      }
+      "For Either[_, String]" in {
+        ExampleFunction.willFailIfNotTwo[EitherString](2) shouldBe Right("That's great!")
+      }
+      "For Either[_, Unit]" in {
+        ExampleFunction.willFailIfNotTwo[EitherUnit](2) shouldBe Right("That's great!")
+      }
+    }
+
+    "Failure" - {
+      "For Try" in {
+        ExampleFunction.willFailIfNotTwo[Try](99) match {
+          case Failure(e) => e.getMessage shouldBe "It's gone wrong!"
+          case _          => fail()
+        }
+      }
+      "For Option" in {
+        ExampleFunction.willFailIfNotTwo[Option](99) shouldBe None
+      }
+      "For Either[_, Throwable]" in {
+        ExampleFunction.willFailIfNotTwo[EitherThrowable](99) match {
+          case Left(e) => e.getMessage shouldBe "It's gone wrong!"
+          case _       => fail()
+        }
+      }
+      "For Either[_, String]" in {
+        ExampleFunction.willFailIfNotTwo[EitherString](99) shouldBe Left("It's gone wrong!")
+      }
+      "For Either[_, Unit]" in {
+        ExampleFunction.willFailIfNotTwo[EitherUnit](99) shouldBe Left(())
+      }
+    }
+  }
+}

--- a/testsuite/src/test/scala/eu/throup/couldbe/MustBeGivenEitherTest.scala
+++ b/testsuite/src/test/scala/eu/throup/couldbe/MustBeGivenEitherTest.scala
@@ -1,0 +1,59 @@
+package eu.throup
+package couldbe
+
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
+
+class MustBeGivenEitherTest extends AnyFreeSpec with Matchers {
+  "Manually constructed" - {
+    "IsGivenLeft[Int, String]" - {
+      val ig = IsGivenLeft[Int, String](123)
+
+      "identifies as left" in {
+        ig.isLeft shouldBe true
+        ig.isRight shouldBe false
+      }
+
+      "toLeft returns value" in {
+        // lambda not used; no exception thrown
+        val output = ig.toLeft(str => throw new Exception(str))
+        output shouldBe 123
+      }
+
+      "toRight uses lambda to return value" in {
+        val output = ig.toRight(int => s"Got this: $int")
+        output shouldBe "Got this: 123"
+      }
+
+      "toEither returns Left of value" in {
+        val output = ig.toEither
+        output shouldBe Left(123)
+      }
+    }
+
+    "IsGivenRight[Int, String]" - {
+      val ig = IsGivenRight[Int, String]("barney")
+
+      "identifies as right" in {
+        ig.isLeft shouldBe false
+        ig.isRight shouldBe true
+      }
+
+      "toLeft uses lambda to return value" in {
+        val output = ig.toLeft(str => str.length)
+        output shouldBe 6
+      }
+
+      "toRight returns value" in {
+        // lambda not used; no exception thrown
+        val output = ig.toRight(int => throw new Exception(s"$int boom!"))
+        output shouldBe "barney"
+      }
+
+      "toEither returns Right of value" in {
+        val output = ig.toEither
+        output shouldBe Right("barney")
+      }
+    }
+  }
+}


### PR DESCRIPTION
Allows for specifying combinations of given instances. For example:

    def func[F[_]: MustBeOneOf2[Applicative, MonadThrow] = ???

This is work in progress, and will reduce test coverage.